### PR TITLE
Fix non-functional drag and drop with setDraggingSourceOperationMask.

### DIFF
--- a/Table Test/ViewController.swift
+++ b/Table Test/ViewController.swift
@@ -7,6 +7,7 @@ class ViewController: NSViewController {
     super.viewDidLoad()
 
     // Do any additional setup after loading the view.
+    tableView.setDraggingSourceOperationMask(.every, forLocal: false)
   }
 
   override var representedObject: Any? {


### PR DESCRIPTION
Fix non-functional drag and drop with `tableView.setDraggingSourceOperationMask(.every, forLocal: false)`.